### PR TITLE
Snowpack percentage function

### DIFF
--- a/collect/dwr/cdec/queries.py
+++ b/collect/dwr/cdec/queries.py
@@ -469,12 +469,6 @@ def get_daily_snowpack_data(region, start, end):
     if region not in ['NORTH', 'SOUTH', 'CENTRAL', 'STATE']:
         raise ValueError(f'<region> string must be NORTH, SOUTH, CENTRAL, or STATE.')
 
-    # validate date string is within range
-    # if start < dt.datetime(2003, 2, 15):
-    #     raise ValueError(f'<start> time cannot be earlier than 2003-2-15.')
-    # if end > dt.datetime.now():
-    #     raise ValueError(f'<end> time cannot be later than today.')
-
     # read in snowpack region table as dataframe
     df = pd.read_html(f'https://cdec.water.ca.gov/dynamicapp/querySWC?reg={region}')[0]
     df['Date'] = pd.to_datetime(df['Date'])
@@ -485,6 +479,12 @@ def get_daily_snowpack_data(region, start, end):
 
     # slice dataframe for query range
     df_query = df.loc[start:end]
+
+    # issue warning if dates are outside of possible query range
+    if start < df.index[0]:
+        print(f'WARNING: <start> time should not be earlier than {df.index[0]}.')
+    if end > df.index[-1]:
+        print(f'WARNING: <end> time should not be later than {df.index[-1]}')
     
     return {'info': {'interval': 'daily',
                      'region': region},


### PR DESCRIPTION
Closes #81; also addresses [MBKEngineers/safca-portal#77](https://github.com/MBKEngineers/safca-portal/issues/77)

- Adds `get_daily_snowpack_data` function to CDEC queries.py
- Takes in `region` and `date_string` (YYYYMMDD) as arguments; `date_string` is optional argument, will use today's date if none provided
- Returns dictionary with metadata and data for % values

### Code to test
```python
from collect.dwr import cdec

data = cdec.get_daily_snowpack_data('CENTRAL')
print(data['meta'])
print(data['data'])
```