### PR TITLE
Bugfix: Bypass parsing CDEC reservoir metadata when URL is invalid

### DIFF
--- a/collect/dwr/cdec/queries.py
+++ b/collect/dwr/cdec/queries.py
@@ -270,8 +270,7 @@ def get_station_metadata(station, as_geojson=False):
         site_info.update(get_dam_metadata(station))
 
     if soup.find('a', href=True, text='Reservoir Information'):
-        if station not in ['BAR', 'BHC', 'FRM', 'KKR', 'PRA', 'SJT', 'DNP', 'LGR']:
-            site_info.update(get_reservoir_metadata(station))
+        site_info.update(get_reservoir_metadata(station))
 
     # export a geojson feature (as dictionary)
     if as_geojson:
@@ -293,6 +292,10 @@ def get_dam_metadata(station):
         info (dict): the CDEC station metadata, stored as key, value pairs
     """
     url = 'https://cdec.water.ca.gov/dynamicapp/profile?s={station}&type=dam'.format(station=station)
+
+    # interrupt if URL is invalid
+    if not get_web_status(url):
+        return {}
 
     # request dam info page
     soup = BeautifulSoup(requests.get(url).content, 'lxml')
@@ -318,7 +321,11 @@ def get_reservoir_metadata(station):
         info (dict): the CDEC station metadata, stored as key, value pairs
     """
     url = 'https://cdec.water.ca.gov/dynamicapp/profile?s={station}&type=res'.format(station=station)
-    
+
+    # interrupt if URL is invalid
+    if not get_web_status(url):
+        return {}
+
     # request dam info page
     soup = BeautifulSoup(requests.get(url).content, 'lxml')
 

--- a/collect/dwr/cdec/queries.py
+++ b/collect/dwr/cdec/queries.py
@@ -264,13 +264,14 @@ def get_station_metadata(station, as_geojson=False):
     site_info['sensors'].update(_parse_station_sensors_table(tables[_get_table_index('sensors', tables)]))
 
     # add site url
-    site_info.update({"CDEC URL": f"<a target=\"_blank\" href=\"{url}\">{station}</a>"})
+    site_info.update({'CDEC URL': f"<a target=\"_blank\" href=\"{url}\">{station}</a>"})
 
     if soup.find('a', href=True, text='Dam Information'):
         site_info.update(get_dam_metadata(station))
 
     if soup.find('a', href=True, text='Reservoir Information'):
-        site_info.update(get_reservoir_metadata(station))
+        if station not in ['BAR', 'BHC', 'FRM', 'KKR', 'PRA', 'SJT', 'DNP', 'LGR']:
+            site_info.update(get_reservoir_metadata(station))
 
     # export a geojson feature (as dictionary)
     if as_geojson:


### PR DESCRIPTION
Check the web status for station dam and reservoir metadata before parsing with BeautifulSoup.

Closes #86 