### PR TITLE
Download watershed file function bugfix when path=None

### DIFF
--- a/collect/cnrfc/cnrfc.py
+++ b/collect/cnrfc/cnrfc.py
@@ -503,9 +503,9 @@ def download_watershed_file(watershed, date_string, forecast_type, duration=None
         date_string (str): the forecast issuance date as a YYYYMMDDHH formatted string
         forecast_type (str): one of deterministic or ensemble
         duration (str): forecast data timestep (hourly or daily)
-        path (str): file name including file path/s3 key
+        path (str): file name including file path
     Returns:
-        (path): file name including file path/s3 key
+        (path): file name including file path
     """
     # store original date_string
     _date_string = date_string
@@ -550,6 +550,7 @@ def download_watershed_file(watershed, date_string, forecast_type, duration=None
         f.write(csvdata.read())
 
     return path
+
 
 def get_watershed_forecast_issue_time(duration, watershed, date_string=None, deterministic=False):
     """

--- a/collect/cnrfc/cnrfc.py
+++ b/collect/cnrfc/cnrfc.py
@@ -539,13 +539,13 @@ def download_watershed_file(watershed, date_string, forecast_type, duration=None
 
     # set path for case where path set to None
     if path is None:
-        filename = url.split('/')[-1].replace('.zip', '.csv')
-        path = os.path.join(os.getcwd(), filename)
+        path = url.split('/')[-1].replace('.zip', '.csv')
 
     # write csvdata to specified path
     path = path.replace('/', os.sep)
-    if not os.path.exists(os.path.dirname(path)):
-        os.makedirs(os.path.dirname(path))
+    if os.path.dirname(path) != '':
+        if not os.path.exists(os.path.dirname(path)):
+            os.makedirs(os.path.dirname(path))
     with open(path, 'wb') as f:
         f.write(csvdata.read())
 

--- a/collect/cnrfc/cnrfc.py
+++ b/collect/cnrfc/cnrfc.py
@@ -539,7 +539,8 @@ def download_watershed_file(watershed, date_string, forecast_type, duration=None
 
     # set path for case where path set to None
     if path is None:
-        path = url.split('/')[-1].replace('.zip', '.csv')
+        filename = url.split('/')[-1].replace('.zip', '.csv')
+        path = os.path.join(os.getcwd(), filename)
 
     # write csvdata to specified path
     path = path.replace('/', os.sep)

--- a/collect/cnrfc/cnrfc.py
+++ b/collect/cnrfc/cnrfc.py
@@ -541,11 +541,12 @@ def download_watershed_file(watershed, date_string, forecast_type, duration=None
     if path is None:
         path = url.split('/')[-1].replace('.zip', '.csv')
 
-    # write csvdata to specified path
+    # write csv data to specified path
     path = path.replace('/', os.sep)
-    if os.path.dirname(path) != '':
-        if not os.path.exists(os.path.dirname(path)):
-            os.makedirs(os.path.dirname(path))
+    directory = os.path.dirname(path)
+    if directory != '':
+        if not os.path.exists(directory):
+            os.makedirs(directory)
     with open(path, 'wb') as f:
         f.write(csvdata.read())
 


### PR DESCRIPTION
Closes #96 

- If path is none, saves file to current working directory as intended


### MWE
```python
from collect.cnrfc import cnrfc
cnrfc.download_watershed_file('FeatherYuba', '2023062112', 'ensemble', duration='hourly')
```