### PR TITLE
Add CDEC Rating Flag for BRT/ART

### DIFF
--- a/collect/dwr/cdec/queries.py
+++ b/collect/dwr/cdec/queries.py
@@ -5,7 +5,6 @@ access CDEC gage data
 """
 # -*- coding: utf-8 -*-
 import datetime as dt
-import numpy as np
 import json
 from bs4 import BeautifulSoup
 import pandas as pd
@@ -110,7 +109,7 @@ def get_station_sensors(station, start, end):
     return sensors
 
 
-def get_station_data(station, start, end, sensors=[], duration='', filename=None):
+def get_station_data(station, start, end, sensors=[], duration=''):
     """
     General purpose function for returning a pandas DataFrame for all available
     data for CDEC `station` in the given time window, with optional `duration` argument.
@@ -121,11 +120,10 @@ def get_station_data(station, start, end, sensors=[], duration='', filename=None
         end (dt.datetime): query end date
         sensors (list): list of the numeric sensor codes
         duration (str): interval code for timeseries data (ex: 'H')
-        filename (str): optional filename for locally saving data
     Returns:
         df (pandas.DataFrame): the queried timeseries as a DataFrame
     """
-    return get_raw_station_csv(station, start, end, sensors, duration, filename)
+    return get_raw_station_csv(station, start, end, sensors, duration)
 
 
 def get_raw_station_csv(station, start, end, sensors=[], duration='', filename=None):
@@ -170,8 +168,7 @@ def get_raw_station_csv(station, start, end, sensors=[], duration='', filename=N
     #report if the data is BRT or ART (below/above rating table)
     df.loc[df['VALUE'] == 'BRT', 'RATING_FLAG'] = 'BRT'
     df.loc[df['VALUE'] == 'ART', 'RATING_FLAG'] = 'ART'
-    df['VALUE'] = df['VALUE'].replace({'BRT': np.nan, 'ART': np.nan})
-    df['DATE TIME'] = df.index
+    df['VALUE'] = df['VALUE'].replace({'BRT': None, 'ART': None}).astype(float)
 
     if bool(filename):
         df.to_csv(filename)

--- a/collect/dwr/cdec/queries.py
+++ b/collect/dwr/cdec/queries.py
@@ -110,7 +110,7 @@ def get_station_sensors(station, start, end):
     return sensors
 
 
-def get_station_data(station, start, end, sensors=[], duration='', filename=''):
+def get_station_data(station, start, end, sensors=[], duration='', filename=None):
     """
     General purpose function for returning a pandas DataFrame for all available
     data for CDEC `station` in the given time window, with optional `duration` argument.
@@ -121,13 +121,14 @@ def get_station_data(station, start, end, sensors=[], duration='', filename=''):
         end (dt.datetime): query end date
         sensors (list): list of the numeric sensor codes
         duration (str): interval code for timeseries data (ex: 'H')
+        filename (str): optional filename for locally saving data
     Returns:
         df (pandas.DataFrame): the queried timeseries as a DataFrame
     """
     return get_raw_station_csv(station, start, end, sensors, duration, filename)
 
 
-def get_raw_station_csv(station, start, end, sensors=[], duration='', filename=''):
+def get_raw_station_csv(station, start, end, sensors=[], duration='', filename=None):
     """
     Use CDEC CSV query URL to download available data.  Optional `filename` argument
     specifies custom file location for download of CSV records.
@@ -153,7 +154,6 @@ def get_raw_station_csv(station, start, end, sensors=[], duration='', filename='
         'SENSOR_TYPE': str,
         'DATE TIME': str,
         'OBS DATE': str,
-        # 'VALUE': (float, str),
         'DATA_FLAG': str,
         'UNITS': str,
     }
@@ -173,7 +173,7 @@ def get_raw_station_csv(station, start, end, sensors=[], duration='', filename='
     df['VALUE'] = df['VALUE'].replace({'BRT': np.nan, 'ART': np.nan})
     df['DATE TIME'] = df.index
 
-    if filename != '':
+    if bool(filename):
         df.to_csv(filename)
 
     if bool(sensors):

--- a/collect/dwr/cdec/queries.py
+++ b/collect/dwr/cdec/queries.py
@@ -109,7 +109,7 @@ def get_station_sensors(station, start, end):
     return sensors
 
 
-def get_station_data(station, start, end, sensors=[], duration=''):
+def get_station_data(station, start, end, sensors=[], duration='', filename=None):
     """
     General purpose function for returning a pandas DataFrame for all available
     data for CDEC `station` in the given time window, with optional `duration` argument.
@@ -120,10 +120,11 @@ def get_station_data(station, start, end, sensors=[], duration=''):
         end (dt.datetime): query end date
         sensors (list): list of the numeric sensor codes
         duration (str): interval code for timeseries data (ex: 'H')
+        filename (str): optional filename for locally saving data
     Returns:
         df (pandas.DataFrame): the queried timeseries as a DataFrame
     """
-    return get_raw_station_csv(station, start, end, sensors, duration)
+    return get_raw_station_csv(station, start, end, sensors, duration, filename)
 
 
 def get_raw_station_csv(station, start, end, sensors=[], duration='', filename=None):

--- a/collect/dwr/swp.py
+++ b/collect/dwr/swp.py
@@ -13,6 +13,7 @@ try:
     import pdftotext
 except:
     print('Module pdftotext is required for SWP report collection.  Install with `pip install pdftotext==2.2.2`')
+
 import requests
 
 

--- a/collect/dwr/swp.py
+++ b/collect/dwr/swp.py
@@ -13,7 +13,6 @@ try:
     import pdftotext
 except:
     print('Module pdftotext is required for SWP report collection.  Install with `pip install pdftotext==2.2.2`')
-
 import requests
 
 


### PR DESCRIPTION
Adds a new column ("RATING_FLAG") to the DataFrame returned by get_raw_station_csv() that indicates if the data was BRT (below rating table) or ART (above rating table).
Removes duplicate 'DATE_TIME' column.

Example:
```
cdec.get_station_data('CBP', start=dt.datetime(2023, 11, 24, 12), end=dt.datetime(2023, 11, 26, 12), sensors=[20, 1, 41])
```
Result:
<img width="1143" alt="image" src="https://github.com/MBKEngineers/collect/assets/85507864/8f52daa7-bd17-4773-a749-1bc5b0f7cd21">
