### PR TITLE
Fix timezone issue in wcds data and truncate to start/end

### DIFF
--- a/collect/usace/wcds.py
+++ b/collect/usace/wcds.py
@@ -54,7 +54,7 @@ def get_water_year_data(reservoir, water_year, interval='d'):
 
     # Convert to date time object
     df.set_index('ISO 8601 Date Time', inplace=True)
-    df.index = pd.to_datetime(df.index)
+    df.index = pd.to_datetime(df.index.str.replace('T24:', ' '))
 
     # Define variable for reservoir metadata
     metadata_dict = get_reservoir_metadata(reservoir, water_year, interval)

--- a/collect/usace/wcds.py
+++ b/collect/usace/wcds.py
@@ -54,7 +54,12 @@ def get_water_year_data(reservoir, water_year, interval='d'):
 
     # Convert to date time object
     df.set_index('ISO 8601 Date Time', inplace=True)
-    df.index = pd.to_datetime(df.index.str.replace('T24:', ' '))
+    
+    # add a day to timesteps where 24T is in the index
+    new_index = pd.Series(pd.to_datetime(df.index.str.replace('T24:', ' ')), index=df.index)
+    mask = df.index.str.contains('T24:')
+    new_index[mask] += pd.Timedelta(days=1)
+    df.index = new_index.values
 
     # Define variable for reservoir metadata
     metadata_dict = get_reservoir_metadata(reservoir, water_year, interval)


### PR DESCRIPTION
Closes #107 

The WCDS data has a date format that wasn't recognized. This removes the `T24` format but keeps the Pacific timezone info. Also changes the index to a datetime index so that it can be trimmed to the start/end times.

@cmora1es FYI

MWE:
Check daily for NBB and hourly for Englebright
```python
nbb_res_data = get_wcds_data(
        'BUL',
        dt.datetime(2024, 10, 1),
        dt.datetime(2024, 10, 10),
        interval='d',
        clean_column_headers=True)

eng_res_data = get_wcds_data(
        'ENG',
        dt.datetime(2024, 10, 1),
        dt.datetime(2024, 10, 10),
        interval='h',
        clean_column_headers=True)

```