### PR TITLE
Update WCDS functions timezones

### DIFF
--- a/collect/usace/wcds.py
+++ b/collect/usace/wcds.py
@@ -355,7 +355,7 @@ def extract_sac_valley_fcr_data(datetime_structure):
             specific to Sacramento Valley
     """
     last_date = dt.datetime(2014, 2, 5, 12, tzinfo=utils.tz_function('UTC'))
-    if datetime_structure.astimezone(dt.timezone.utc) < last_date:
+    if datetime_structure.astimezone(utils.tz_function('UTC')) < last_date:
         print(f'WARNING: Sac Valley table unavailable before {last_date:%Y-%m-%d}')
         return None
 

--- a/collect/usace/wcds.py
+++ b/collect/usace/wcds.py
@@ -339,7 +339,7 @@ def extract_fcr_text(datetime_structure):
         raise NotImplementedError(f'Date unavailable: {datetime_structure_pacific:%Y-%m-%d}')
 
     url = f'https://www.spk-wc.usace.army.mil/fcgi-bin/midnight.py?days={days+1}&report=FCR&textonly=true'
-    content = requests.get(url, verify=ssl.CERT_NONE).text
+    content = utils.get_session_response(url, verify=ssl.CERT_NONE).text
     # get the list of text between Sacramento Valley and San Joaquin Valley
     return re.findall(r'(?<=Sacramento Valley)[\S\s]*(?=San Joaquin Valley)', content)
 


### PR DESCRIPTION
Assert that provided datetime to WCDS FCR methods is timezone aware. Other updates include changes to make sure that the dates are compared correctly based on the Pacific timezone and use `get_session_response` instead of regular requests.

### MWE

```python
get_fcr_data(dt.datetime(2025, 7, 1, 1).replace(tzinfo=utils.tz_function('US/Pacific')))
get_fcr_data(dt.datetime(2024, 12, 10, 12).replace(tzinfo=utils.tz_function('UTC')))

# this should fail
get_fcr_data(dt.datetime(2024, 12, 10, 12))
```